### PR TITLE
Fixed empty attribute list handling

### DIFF
--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/AttributeDesignator.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/AttributeDesignator.java
@@ -10,12 +10,12 @@ package org.xacml4j.v30.pdp;
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -82,38 +82,48 @@ public class AttributeDesignator extends AttributeReference
 	public BagOfAttributeExp evaluate(EvaluationContext context)
 			throws EvaluationException
 	{
-		BagOfAttributeExp v = null;
-		try{
+		BagOfAttributeExp v;
+		try {
 			v = designatorKey.resolve(context);
-		}catch(AttributeReferenceEvaluationException e){
-			if(log.isDebugEnabled()){
-				log.debug("Reference=\"{}\" evaluation " +
-						"failed with error=\"{}\"",
-						toString(), e.getMessage());
+		} catch (AttributeReferenceEvaluationException e) {
+			if (log.isDebugEnabled()) {
+				log.debug("Reference=\"{}\" evaluation failed with error=\"{}\"",
+				          this, e.getMessage());
 			}
-			if(isMustBePresent()){
+			if (isMustBePresent()) {
 				throw e;
 			}
 			return getDataType().bagType().createEmpty();
-		}catch(Exception e){
-			if(log.isDebugEnabled()){
-				log.debug("Reference=\"{}\" evaluation " +
-						"failed with error=\"{}\"",
-						toString(), e.getMessage());
+		} catch (Exception e) {
+			if (log.isDebugEnabled()) {
+				log.debug("Reference=\"{}\" evaluation failed with error=\"{}\"",
+				          this, e.getMessage());
 			}
-			if(isMustBePresent()){
+			if (isMustBePresent()) {
 				throw new AttributeReferenceEvaluationException(designatorKey);
+			}
+			if (log.isDebugEnabled()) {
+				log.debug("Returning an empty bag for attributeId=\"{}\", category=\"{}\"",
+				          designatorKey.getAttributeId(), designatorKey.getCategory());
 			}
 			return getDataType().bagType().createEmpty();
 		}
-		if((v == null || v.isEmpty()) && isMustBePresent()){
-			if(log.isDebugEnabled()){
-				log.debug("Failed to resolve attributeId=\"{}\", category=\"{}\"",
-						designatorKey.getAttributeId(), designatorKey.getCategory());
-			}
-			throw new AttributeReferenceEvaluationException(designatorKey);
+		if (v == null) {
+			 if (isMustBePresent()) {
+				 if (log.isDebugEnabled()) {
+					 log.debug("Failed to resolve attributeId=\"{}\", category=\"{}\"",
+					           designatorKey.getAttributeId(), designatorKey.getCategory());
+				 }
+				 throw new AttributeReferenceEvaluationException(designatorKey);
+			 } else {
+			 	if (log.isDebugEnabled()) {
+				    log.debug("Returning an empty bag for attributeId=\"{}\", category=\"{}\"",
+				              designatorKey.getAttributeId(), designatorKey.getCategory());
+			    }
+			 	return getDataType().bagType().createEmpty();
+			 }
 		}
-		return (v == null) ? getDataType().bagType().createEmpty() : v;
+		return v;
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/pip/DefaultResolverContext.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/pip/DefaultResolverContext.java
@@ -80,7 +80,12 @@ final class DefaultResolverContext implements
 		}
 		ImmutableList.Builder<BagOfAttributeExp> b = ImmutableList.builder();
 		for(AttributeReferenceKey ref : keyRefs){
-			b.add(ref.resolve(context));
+			BagOfAttributeExp v = ref.resolve(context);
+			if (v != null) {
+				b.add(v);
+			} else {
+				b.add(ref.getDataType().emptyBag());
+			}
 		}
 		return b.build();
 	}

--- a/xacml-core/src/test/java/org/xacml4j/v30/pdp/AttributeDesignatorTest.java
+++ b/xacml-core/src/test/java/org/xacml4j/v30/pdp/AttributeDesignatorTest.java
@@ -53,9 +53,8 @@ public class AttributeDesignatorTest
 		this.context = createStrictMock(EvaluationContext.class);
 	}
 
-	@Test(expected=AttributeReferenceEvaluationException.class)
-	public void testMustBePresentTrueAttributeDoesNotExistAndContextHandlerReturnsEmptyBag() throws EvaluationException
-	{
+	@Test
+	public void testMustBePresentTrueAttributeDoesNotExistAndContextHandlerReturnsEmptyBag() throws EvaluationException {
 		AttributeDesignator desig = AttributeDesignator
 				.builder()
 				.category(Categories.SUBJECT_RECIPIENT)
@@ -67,13 +66,9 @@ public class AttributeDesignatorTest
 		Capture<AttributeDesignatorKey> c = new Capture<AttributeDesignatorKey>();
 		expect(context.resolve(capture(c))).andReturn(XacmlTypes.INTEGER.emptyBag());
 		replay(context);
-		try{
-			desig.evaluate(context);
-		}catch(AttributeReferenceEvaluationException e){
-			assertSame(c.getValue(), e.getReference());
-			assertTrue(e.getStatus().isFailure());
-			throw e;
-		}
+		Expression v = desig.evaluate(context);
+		assertEquals(XacmlTypes.INTEGER.bagType(), v.getEvaluatesTo());
+		assertEquals(XacmlTypes.INTEGER.emptyBag(), v);
 		verify(context);
 	}
 
@@ -101,7 +96,6 @@ public class AttributeDesignatorTest
 		}
 		verify(context);
 	}
-
 
 	@Test
 	public void testMustBePresentTrueAttributeDoesExist() throws EvaluationException

--- a/xacml-core/src/test/java/org/xacml4j/v30/pdp/AttributeSelectorTest.java
+++ b/xacml-core/src/test/java/org/xacml4j/v30/pdp/AttributeSelectorTest.java
@@ -71,7 +71,7 @@ public class AttributeSelectorTest
 	}
 
 	@Test
-	public void testMustBePresenFalseAndReturnsNonEmptyBag() throws EvaluationException
+	public void testMustBePresentFalseAndReturnsNonEmptyBag() throws EvaluationException
 	{
 		AttributeSelector ref = AttributeSelector
 				.builder()
@@ -90,7 +90,7 @@ public class AttributeSelectorTest
 	}
 
 	@Test(expected=AttributeReferenceEvaluationException.class)
-	public void testMustBePresenTrueAndReturnsEmptyBag() throws EvaluationException
+	public void testMustBePresentTrueAndReturnsEmptyBag() throws EvaluationException
 	{
 		AttributeSelector ref = AttributeSelector
 				.builder()
@@ -107,7 +107,7 @@ public class AttributeSelectorTest
 	}
 
 	@Test
-	public void testMustBePresenFalseAndReturnsEmptyBag() throws EvaluationException
+	public void testMustBePresentFalseAndReturnsEmptyBag() throws EvaluationException
 	{
 		AttributeSelector ref = AttributeSelector
 				.builder()
@@ -126,7 +126,7 @@ public class AttributeSelectorTest
 	}
 
 	@Test
-	public void testMustBePresenFalseAndContextThrowsAttributeReferenceEvaluationException() throws EvaluationException
+	public void testMustBePresentFalseAndContextThrowsAttributeReferenceEvaluationException() throws EvaluationException
 	{
 		AttributeSelector ref = AttributeSelector
 				.builder()
@@ -147,7 +147,7 @@ public class AttributeSelectorTest
 	}
 
 	@Test
-	public void testMustBePresenFalseAndContextThrowsRuntimeException() throws EvaluationException
+	public void testMustBePresentFalseAndContextThrowsRuntimeException() throws EvaluationException
 	{
 		AttributeSelector ref = AttributeSelector
 				.builder()
@@ -166,7 +166,7 @@ public class AttributeSelectorTest
 	}
 
 	@Test(expected=AttributeReferenceEvaluationException.class)
-	public void testMustBePresenTrueAndContextThrowsRuntimeException() throws EvaluationException
+	public void testMustBePresentTrueAndContextThrowsRuntimeException() throws EvaluationException
 	{
 		AttributeSelector ref = AttributeSelector
 				.builder()
@@ -183,7 +183,7 @@ public class AttributeSelectorTest
 	}
 
 	@Test(expected=AttributeReferenceEvaluationException.class)
-	public void testMustBePresenTrueAndContextThrowsAttributeReferenceEvaluationException() throws EvaluationException
+	public void testMustBePresentTrueAndContextThrowsAttributeReferenceEvaluationException() throws EvaluationException
 	{
 		AttributeSelector ref = AttributeSelector
 				.builder()


### PR DESCRIPTION
- Allow empty attribute lists while resolving attributes from request context
- Fix `MustBePresent` AttributeDesignator rule and don't convert missing attributes to an empty bag
