### PR TITLE
Guava dependency version upgrade, Sets.cartesianProduct() populates List<Category> in lexicographical order in newer version. However in older version, this order wasn't guaranteed. https://guava.dev/releases/24.1.1-jre/api/docs/com/google/common/collect/Sets.html#cartesianProduct-java.util.List- https://guava.dev/releases/13.0/api/docs/com/google/common/collect/Sets.html#cartesianProduct(java.util.List)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<slf4j.version>1.6.1</slf4j.version>
 		<log4j.version>1.2.14</log4j.version>
 		<easymock.version>3.1</easymock.version>
-		<guava.version>13.0.1</guava.version>
+		<guava.version>24.1.1-jre</guava.version>
 		<xml.resolver.version>1.2</xml.resolver.version>
 		<yammer.metrics.version>3.0.2</yammer.metrics.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/xacml-core/pom.xml
+++ b/xacml-core/pom.xml
@@ -42,6 +42,14 @@
 					<schemaDirectory>${basedir}/src/main/xsd</schemaDirectory>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/xacml-core/src/main/java/org/xacml4j/v30/Attribute.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/Attribute.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 
 import org.xacml4j.v30.types.EntityExp;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -116,12 +117,12 @@ public class Attribute
 
 	@Override
 	public final String toString(){
-		return Objects.toStringHelper(this)
-		.add("AttributeId", attributeId)
-		.add("Issuer", issuer)
-		.add("IncludeInResult", includeInResult)
-		.add("Values", values)
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("AttributeId", attributeId)
+		                  .add("Issuer", issuer)
+		                  .add("IncludeInResult", includeInResult)
+		                  .add("Values", values)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/AttributeAssignment.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/AttributeAssignment.java
@@ -24,6 +24,7 @@ package org.xacml4j.v30;
 
 import org.xacml4j.v30.pdp.AttributeAssignmentExpression;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -104,11 +105,11 @@ public class AttributeAssignment
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("attributeId", attributeId)
-		.add("category", category)
-		.add("value", attribute)
-		.add("issuer", issuer).toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("attributeId", attributeId)
+		                  .add("category", category)
+		                  .add("value", attribute)
+		                  .add("issuer", issuer).toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/AttributeDesignatorKey.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/AttributeDesignatorKey.java
@@ -22,6 +22,7 @@ package org.xacml4j.v30;
  * #L%
  */
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -71,11 +72,11 @@ public final class AttributeDesignatorKey
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("Category", getCategory())
-		.add("AttributeId", attributeId)
-		.add("DataType", getDataType())
-		.add("Issuer", issuer).toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("Category", getCategory())
+		                  .add("AttributeId", attributeId)
+		                  .add("DataType", getDataType())
+		                  .add("Issuer", issuer).toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/AttributeSelectorKey.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/AttributeSelectorKey.java
@@ -22,6 +22,7 @@ package org.xacml4j.v30;
  * #L%
  */
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -83,11 +84,11 @@ public final class AttributeSelectorKey
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("Category", getCategory())
-		.add("Path", xpath)
-		.add("DataType", getDataType())
-		.add("ContextSelectorId", contextSelectorId).toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("Category", getCategory())
+		                  .add("Path", xpath)
+		                  .add("DataType", getDataType())
+		                  .add("ContextSelectorId", contextSelectorId).toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/BagOfAttributeExp.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/BagOfAttributeExp.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMultiset;
@@ -242,7 +243,7 @@ public final class BagOfAttributeExp
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this).
+		return MoreObjects.toStringHelper(this).
 		add("DataType", type.getDataType()).
 		add("Values", values).toString();
 	}

--- a/xacml-core/src/main/java/org/xacml4j/v30/BagOfAttributeExpType.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/BagOfAttributeExpType.java
@@ -25,6 +25,7 @@ package org.xacml4j.v30;
 import java.util.Arrays;
 import java.util.Collections;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -121,8 +122,8 @@ public final class BagOfAttributeExpType implements ValueType
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("TypeId", type.getDataTypeId())
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("TypeId", type.getDataTypeId())
+		                  .toString();
 	}
 }

--- a/xacml-core/src/main/java/org/xacml4j/v30/BaseDecisionRuleResponse.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/BaseDecisionRuleResponse.java
@@ -24,6 +24,7 @@ package org.xacml4j.v30;
 
 import java.util.Collection;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -87,11 +88,11 @@ public abstract class BaseDecisionRuleResponse
 
 	@Override
 	public final String toString(){
-		return Objects.toStringHelper(this)
-		.add("id", id)
-		.add("attributes", attributes)
-		.add("fullFillOn", fulfillOn)
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("id", id)
+		                  .add("attributes", attributes)
+		                  .add("fullFillOn", fulfillOn)
+		                  .toString();
 	}
 
 	public abstract static class Builder<T extends Builder<?>>

--- a/xacml-core/src/main/java/org/xacml4j/v30/Category.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/Category.java
@@ -22,6 +22,7 @@ package org.xacml4j.v30;
  * #L%
  */
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -96,11 +97,11 @@ public class Category
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("category", categoryId)
-		.add("id", id)
-		.add("entity", entity)
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("category", categoryId)
+		                  .add("id", id)
+		                  .add("entity", entity)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/CategoryReference.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/CategoryReference.java
@@ -22,6 +22,7 @@ package org.xacml4j.v30;
  * #L%
  */
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -51,9 +52,9 @@ public class CategoryReference
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("referenceId", referenceId)
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("referenceId", referenceId)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/DNSName.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/DNSName.java
@@ -67,7 +67,7 @@ public final class DNSName implements Serializable
 	}
 
 	public String getDomainName(){
-		return name.name();
+		return name.toString();
 	}
 
 	/**
@@ -101,7 +101,7 @@ public final class DNSName implements Serializable
 	}
 
 	public String getPublicSuffix(){
-		return name.publicSuffix().name();
+		return name.publicSuffix().toString();
 	}
 
 	public List<String> getDomainNameParts(){
@@ -113,7 +113,7 @@ public final class DNSName implements Serializable
 	}
 
 	public String getTopPrivateDomain(){
-		return name.topPrivateDomain().name();
+		return name.topPrivateDomain().toString();
 	}
 
 	@Override
@@ -142,7 +142,7 @@ public final class DNSName implements Serializable
 	}
 
 	public String toXacmlString() {
-		StringBuilder b = new StringBuilder(name.name());
+		StringBuilder b = new StringBuilder(name.toString());
 		if(!portRange.isUnbound()){
 			b.append(':').append(portRange.toString());
 		}

--- a/xacml-core/src/main/java/org/xacml4j/v30/Entity.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/Entity.java
@@ -42,6 +42,7 @@ import org.xacml4j.v30.types.TypeToString;
 import org.xacml4j.v30.types.XPathExp;
 import org.xacml4j.v30.types.XacmlTypes;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -231,10 +232,10 @@ public final class Entity extends AttributeContainer
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("attributes", attributes)
-		.add("content", (content != null)?DOMUtil.toString(content.getDocumentElement()):content)
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("attributes", attributes)
+		                  .add("content", (content != null)?DOMUtil.toString(content.getDocumentElement()):content)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/RequestContext.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/RequestContext.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Set;
 
 import com.google.common.base.Function;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
@@ -348,12 +349,12 @@ public class RequestContext
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("ReturnPolicyIDList", returnPolicyIdList)
-		.add("CombineDecision", combinedDecision)
-		.addValue(attributes.values())
-		.add("RequestReferences", requestReferences)
-		.add("RequestDefaults", requestDefaults).toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("ReturnPolicyIDList", returnPolicyIdList)
+		                  .add("CombineDecision", combinedDecision)
+		                  .addValue(attributes.values())
+		                  .add("RequestReferences", requestReferences)
+		                  .add("RequestDefaults", requestDefaults).toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/RequestDefaults.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/RequestDefaults.java
@@ -22,9 +22,7 @@ package org.xacml4j.v30;
  * #L%
  */
 
-import com.google.common.base.Objects;
-
-
+import com.google.common.base.MoreObjects;
 
 public class RequestDefaults
 {
@@ -44,9 +42,9 @@ public class RequestDefaults
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-				.add("xpathVersion", xpathVersion)
-				.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("xpathVersion", xpathVersion)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/RequestReference.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/RequestReference.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 
 import org.xacml4j.v30.pdp.RequestSyntaxException;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
@@ -57,7 +58,7 @@ public class RequestReference
 
 	@Override
 	public String toString(){
-		return Objects
+		return MoreObjects
 				.toStringHelper(this)
 				.add("references", references)
 				.toString();

--- a/xacml-core/src/main/java/org/xacml4j/v30/ResponseContext.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/ResponseContext.java
@@ -24,6 +24,7 @@ package org.xacml4j.v30;
 
 import java.util.Collection;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -51,7 +52,7 @@ public class ResponseContext
 
 	@Override
 	public String toString(){
-		return Objects
+		return MoreObjects
 				.toStringHelper(this)
 				.add("results", results)
 				.toString();

--- a/xacml-core/src/main/java/org/xacml4j/v30/Result.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/Result.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableCollection;
@@ -199,7 +200,7 @@ public class Result
 
 	@Override
 	public String toString(){
-		return Objects
+		return MoreObjects
 				.toStringHelper(this)
 				.add("status", status)
 				.add("decision", decision)

--- a/xacml-core/src/main/java/org/xacml4j/v30/Status.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/Status.java
@@ -22,6 +22,7 @@ package org.xacml4j.v30;
  * #L%
  */
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -109,11 +110,11 @@ public final class Status
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-				.add("code", code)
-				.add("message", message)
-				.add("detail", detail)
-				.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("code", code)
+		                  .add("message", message)
+		                  .add("detail", detail)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/StatusCode.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/StatusCode.java
@@ -22,6 +22,7 @@ package org.xacml4j.v30;
  * #L%
  */
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -97,10 +98,10 @@ public class StatusCode
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-				.add("code", value)
-				.add("minorStatus", minorStatus)
-				.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("code", value)
+		                  .add("minorStatus", minorStatus)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/Version.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/Version.java
@@ -24,7 +24,7 @@ package org.xacml4j.v30;
 
 import java.util.regex.Pattern;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
@@ -80,7 +80,7 @@ public final class Version implements Comparable<Version>
 
     @Override
     public String toString(){
-    	return Objects.toStringHelper(this).
+    	return MoreObjects.toStringHelper(this).
     	add("version", value).toString();
     }
 

--- a/xacml-core/src/main/java/org/xacml4j/v30/XPathExpression.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/XPathExpression.java
@@ -22,7 +22,7 @@ package org.xacml4j.v30;
  * #L%
  */
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
 public final class XPathExpression
@@ -64,8 +64,8 @@ public final class XPathExpression
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-				.add("category", categoryId.toString())
-				.add("path", path).toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("category", categoryId.toString())
+		                  .add("path", path).toString();
 	}
 }

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/Apply.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/Apply.java
@@ -31,6 +31,7 @@ import org.xacml4j.v30.ExpressionVisitor;
 import org.xacml4j.v30.ValueExpression;
 import org.xacml4j.v30.ValueType;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -124,10 +125,10 @@ public class Apply implements Expression
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("function", spec)
-		.add("arguments", arguments)
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("function", spec)
+		                  .add("arguments", arguments)
+		                  .toString();
 	}
 
 	public boolean equals(Object o){

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/AttributeAssignmentExpression.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/AttributeAssignmentExpression.java
@@ -29,6 +29,7 @@ import org.xacml4j.v30.EvaluationException;
 import org.xacml4j.v30.Expression;
 import org.xacml4j.v30.ValueExpression;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -102,12 +103,12 @@ public class AttributeAssignmentExpression implements PolicyElement
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("attributeId", attributeId)
-		.add("category", category)
-		.add("issuer", issuer)
-		.add("expression", expression)
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("attributeId", attributeId)
+		                  .add("category", category)
+		                  .add("issuer", issuer)
+		                  .add("expression", expression)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/AttributeDesignator.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/AttributeDesignator.java
@@ -31,6 +31,7 @@ import org.xacml4j.v30.EvaluationContext;
 import org.xacml4j.v30.EvaluationException;
 import org.xacml4j.v30.ExpressionVisitor;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -125,10 +126,10 @@ public class AttributeDesignator extends AttributeReference
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("designatorKey", designatorKey)
-		.add("mustBePresent", isMustBePresent())
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("designatorKey", designatorKey)
+		                  .add("mustBePresent", isMustBePresent())
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/AttributeSelector.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/AttributeSelector.java
@@ -31,6 +31,7 @@ import org.xacml4j.v30.EvaluationContext;
 import org.xacml4j.v30.EvaluationException;
 import org.xacml4j.v30.ExpressionVisitor;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class AttributeSelector extends
@@ -56,10 +57,10 @@ public class AttributeSelector extends
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("selectorKey", selectorKey)
-		.add("mustBePresent", isMustBePresent())
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("selectorKey", selectorKey)
+		                  .add("mustBePresent", isMustBePresent())
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/BaseCompositeDecisionRule.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/BaseCompositeDecisionRule.java
@@ -34,6 +34,7 @@ import org.xacml4j.v30.EvaluationException;
 import org.xacml4j.v30.MatchResult;
 import org.xacml4j.v30.Version;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMultimap;
@@ -184,7 +185,7 @@ abstract class BaseCompositeDecisionRule extends BaseDecisionRule
 	protected abstract Decision combineDecisions(EvaluationContext context);
 
 	@Override
-	protected Objects.ToStringHelper toStringBuilder(Objects.ToStringHelper b){
+	protected MoreObjects.ToStringHelper toStringBuilder(MoreObjects.ToStringHelper b){
 		return super.toStringBuilder(b)
 			.add("version", version)
 			.add("issuer", policyIssuer)

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/BaseCompositeDecisionRuleDefaults.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/BaseCompositeDecisionRuleDefaults.java
@@ -24,6 +24,7 @@ package org.xacml4j.v30.pdp;
 
 import org.xacml4j.v30.XPathVersion;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -52,7 +53,7 @@ abstract class BaseCompositeDecisionRuleDefaults
 
 	@Override
 	public String toString(){
-		return Objects
+		return MoreObjects
 				.toStringHelper(this)
 				.add("values", values)
 				.toString();

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/BaseCompositeDecisionRuleIDReference.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/BaseCompositeDecisionRuleIDReference.java
@@ -26,6 +26,7 @@ import org.xacml4j.v30.CompositeDecisionRuleIDReference;
 import org.xacml4j.v30.Version;
 import org.xacml4j.v30.VersionMatch;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -102,11 +103,11 @@ public abstract class BaseCompositeDecisionRuleIDReference
 
 	@Override
 	public final String toString() {
-		return Objects.toStringHelper(this)
-		.add("id", id)
-		.add("version", version)
-		.add("earliest", earliest)
-		.add("latest", latest).toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("id", id)
+		                  .add("version", version)
+		                  .add("earliest", earliest)
+		                  .add("latest", latest).toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/BaseDecisionRule.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/BaseDecisionRule.java
@@ -37,6 +37,7 @@ import org.xacml4j.v30.MatchResult;
 import org.xacml4j.v30.Obligation;
 import org.xacml4j.v30.Status;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -269,7 +270,7 @@ abstract class BaseDecisionRule implements DecisionRule
 		}
 	}
 
-	protected Objects.ToStringHelper toStringBuilder(Objects.ToStringHelper b){
+	protected MoreObjects.ToStringHelper toStringBuilder(MoreObjects.ToStringHelper b){
 		return b.add("id", id)
 				.add("description", description)
 				.add("target", target)

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/BaseDecisionRuleResponseExpression.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/BaseDecisionRuleResponseExpression.java
@@ -35,6 +35,7 @@ import org.xacml4j.v30.EvaluationException;
 import org.xacml4j.v30.Expression;
 import org.xacml4j.v30.ValueExpression;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -138,11 +139,11 @@ abstract class BaseDecisionRuleResponseExpression implements PolicyElement
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("id", id)
-		.add("effect", effect)
-		.add("expressions", attributeExpressions)
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("id", id)
+		                  .add("effect", effect)
+		                  .add("expressions", attributeExpressions)
+		                  .toString();
 	}
 
 	public static abstract class Builder<T extends Builder<?>>

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/CombinerParameter.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/CombinerParameter.java
@@ -24,6 +24,7 @@ package org.xacml4j.v30.pdp;
 
 import org.xacml4j.v30.AttributeExp;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -68,10 +69,10 @@ public class CombinerParameter
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("name", name)
-		.add("value", value)
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("name", name)
+		                  .add("value", value)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/Condition.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/Condition.java
@@ -30,6 +30,7 @@ import org.xacml4j.v30.ValueType;
 import org.xacml4j.v30.types.BooleanExp;
 import org.xacml4j.v30.types.XacmlTypes;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -108,7 +109,7 @@ public class Condition implements PolicyElement
 
 	@Override
 	public String toString(){
-		return Objects
+		return MoreObjects
 				.toStringHelper(this)
 				.add("predicate", predicate)
 				.toString();

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/DelegatingEvaluationContext.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/DelegatingEvaluationContext.java
@@ -46,6 +46,7 @@ import org.xacml4j.v30.ValueExpression;
 import org.xacml4j.v30.XPathVersion;
 import org.xacml4j.v30.types.XPathExp;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Ticker;
@@ -290,7 +291,7 @@ abstract class DelegatingEvaluationContext implements EvaluationContext
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this).add("delegate", delegate).toString();
+		return MoreObjects.toStringHelper(this).add("delegate", delegate).toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/FunctionReference.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/FunctionReference.java
@@ -31,6 +31,7 @@ import org.xacml4j.v30.ExpressionVisitor;
 import org.xacml4j.v30.ValueExpression;
 import org.xacml4j.v30.ValueType;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -128,9 +129,9 @@ public class FunctionReference implements Expression
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-				.add("function", spec)
-				.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("function", spec)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/Match.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/Match.java
@@ -32,6 +32,7 @@ import org.xacml4j.v30.EvaluationException;
 import org.xacml4j.v30.MatchResult;
 import org.xacml4j.v30.ValueType;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -151,11 +152,11 @@ public class Match implements PolicyElement, Matchable
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-				.add("MatchId", predicate.getId())
-				.add("Value", value)
-				.add("Reference", attributeRef)
-				.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("MatchId", predicate.getId())
+		                  .add("Value", value)
+		                  .add("Reference", attributeRef)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/MatchAllOf.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/MatchAllOf.java
@@ -30,6 +30,7 @@ import org.xacml4j.v30.AttributeExp;
 import org.xacml4j.v30.EvaluationContext;
 import org.xacml4j.v30.MatchResult;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -88,9 +89,9 @@ public class MatchAllOf implements PolicyElement, Matchable
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-				.add("Matches", matches)
-				.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("Matches", matches)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/MatchAnyOf.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/MatchAnyOf.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.xacml4j.v30.EvaluationContext;
 import org.xacml4j.v30.MatchResult;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -88,9 +89,9 @@ public class MatchAnyOf
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-				.add("AllOf", allOfs)
-				.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("AllOf", allOfs)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/Policy.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/Policy.java
@@ -36,8 +36,9 @@ import org.xacml4j.v30.ValueExpression;
 import org.xacml4j.v30.XPathVersion;
 
 import com.google.common.base.Function;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
@@ -177,7 +178,7 @@ public class Policy extends BaseCompositeDecisionRule
 
 	@Override
 	public String toString(){
-		ToStringHelper h = Objects.toStringHelper(this);
+		ToStringHelper h = MoreObjects.toStringHelper(this);
 		return toStringBuilder(h)
 		.add("variableDefinitions", variableDefinitions)
 		.add("policyDefaults",policyDefaults)

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/RootEvaluationContext.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/RootEvaluationContext.java
@@ -54,6 +54,7 @@ import org.xacml4j.v30.XPathVersion;
 import org.xacml4j.v30.spi.repository.PolicyReferenceResolver;
 import org.xacml4j.v30.types.XPathExp;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Ticker;
@@ -158,7 +159,7 @@ public final class RootEvaluationContext implements EvaluationContext {
 
 	@Override
 	public int getDecisionCacheTTL() {
-		return Objects.firstNonNull(combinedDecisionCacheTTL, 0);
+		return MoreObjects.firstNonNull(combinedDecisionCacheTTL, 0);
 	}
 
 	@Override
@@ -435,7 +436,7 @@ public final class RootEvaluationContext implements EvaluationContext {
 
 	@Override
 	public String toString() {
-		return Objects
+		return MoreObjects
 				.toStringHelper(this)
 				.add("defaultXPathVersion", defaultXPathVersion)
 				.add("contextHandler", contextHandler)

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/Rule.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/Rule.java
@@ -30,6 +30,7 @@ import org.xacml4j.v30.EvaluationContext;
 import org.xacml4j.v30.EvaluationException;
 import org.xacml4j.v30.MatchResult;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -91,7 +92,7 @@ public class Rule extends BaseDecisionRule implements PolicyElement
 
 	@Override
 	public String toString(){
-		return toStringBuilder(Objects.toStringHelper(this))
+		return toStringBuilder(MoreObjects.toStringHelper(this))
 				.add("effect", effect)
 				.toString();
 	}

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/Target.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/Target.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.xacml4j.v30.EvaluationContext;
 import org.xacml4j.v30.MatchResult;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
@@ -118,7 +119,7 @@ public class Target implements PolicyElement
 
 	@Override
 	public String toString(){
-		return Objects
+		return MoreObjects
 				.toStringHelper(this)
 				.add("AnyOf", matches)
 				.toString();

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/VariableDefinition.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/VariableDefinition.java
@@ -30,6 +30,7 @@ import org.xacml4j.v30.Expression;
 import org.xacml4j.v30.ValueExpression;
 import org.xacml4j.v30.ValueType;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -79,10 +80,10 @@ public class VariableDefinition implements PolicyElement
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-				.add("variableId", variableId)
-				.add("expression", expression)
-				.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("variableId", variableId)
+		                  .add("expression", expression)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/pdp/VariableReference.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/pdp/VariableReference.java
@@ -29,7 +29,7 @@ import org.xacml4j.v30.ExpressionVisitor;
 import org.xacml4j.v30.ValueExpression;
 import org.xacml4j.v30.ValueType;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
 public class VariableReference implements Expression
@@ -95,7 +95,7 @@ public class VariableReference implements Expression
 
 	@Override
 	public String toString(){
-		return Objects
+		return MoreObjects
 				.toStringHelper(this)
 				.add("variableDef", varDef)
 				.toString();

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/combine/BaseDecisionCombiningAlgorithm.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/combine/BaseDecisionCombiningAlgorithm.java
@@ -25,6 +25,7 @@ package org.xacml4j.v30.spi.combine;
 import org.xacml4j.v30.DecisionRule;
 import org.xacml4j.v30.pdp.DecisionCombiningAlgorithm;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -74,7 +75,7 @@ public abstract class BaseDecisionCombiningAlgorithm <D extends DecisionRule>
 
 	@Override
 	public final String toString() {
-		return Objects
+		return MoreObjects
 				.toStringHelper(this)
 				.add("algorithmId", algorithmId)
 				.toString();

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionParamAnyAttributeSpec.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionParamAnyAttributeSpec.java
@@ -28,6 +28,7 @@ import org.xacml4j.v30.AttributeExpType;
 import org.xacml4j.v30.Expression;
 import org.xacml4j.v30.ValueType;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 
@@ -51,12 +52,12 @@ final class FunctionParamAnyAttributeSpec extends BaseFunctionParamSpec
 	}
 
 	public String toString(){
-		return Objects.
+		return MoreObjects.
 				toStringHelper(this)
-				.add("optional", isOptional())
-				.add("defaultValue", getDefaultValue())
-				.add("variadic", isVariadic())
-				.toString();
+		                  .add("optional", isOptional())
+		                  .add("defaultValue", getDefaultValue())
+		                  .add("variadic", isVariadic())
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionParamAnyBagSpec.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionParamAnyBagSpec.java
@@ -28,6 +28,7 @@ import org.xacml4j.v30.BagOfAttributeExpType;
 import org.xacml4j.v30.Expression;
 import org.xacml4j.v30.ValueType;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 final class FunctionParamAnyBagSpec extends BaseFunctionParamSpec
@@ -52,12 +53,12 @@ final class FunctionParamAnyBagSpec extends BaseFunctionParamSpec
 
 	@Override
 	public String toString(){
-		return Objects.
+		return MoreObjects.
 				toStringHelper(this)
-				.add("optional", isOptional())
-				.add("defaultValue", getDefaultValue())
-				.add("variadic", isVariadic())
-				.toString();
+		                  .add("optional", isOptional())
+		                  .add("defaultValue", getDefaultValue())
+		                  .add("variadic", isVariadic())
+		                  .toString();
 	}
 	
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionParamFuncReferenceSpec.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionParamFuncReferenceSpec.java
@@ -28,6 +28,7 @@ import org.xacml4j.v30.Expression;
 import org.xacml4j.v30.ValueType;
 import org.xacml4j.v30.pdp.FunctionReference;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 final class FunctionParamFuncReferenceSpec extends BaseFunctionParamSpec
@@ -45,12 +46,12 @@ final class FunctionParamFuncReferenceSpec extends BaseFunctionParamSpec
 
 	@Override
 	public String toString(){
-		return Objects.
+		return MoreObjects.
 				toStringHelper(this)
-				.add("optional", isOptional())
-				.add("defaultValue", getDefaultValue())
-				.add("variadic", isVariadic())
-				.toString();
+		                  .add("optional", isOptional())
+		                  .add("defaultValue", getDefaultValue())
+		                  .add("variadic", isVariadic())
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionParamValueTypeSequenceSpec.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionParamValueTypeSequenceSpec.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.xacml4j.v30.Expression;
 import org.xacml4j.v30.ValueType;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 
@@ -129,7 +130,7 @@ final class FunctionParamValueTypeSequenceSpec extends BaseFunctionParamSpec
 
 	@Override
 	public String toString(){
-		return Objects
+		return MoreObjects
 				.toStringHelper(this)
 				.add("min", min)
 				.add("max", max)

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionParamValueTypeSpec.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionParamValueTypeSpec.java
@@ -30,6 +30,7 @@ import org.xacml4j.v30.Expression;
 import org.xacml4j.v30.ValueExpression;
 import org.xacml4j.v30.ValueType;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -87,7 +88,7 @@ final class FunctionParamValueTypeSpec extends BaseFunctionParamSpec
 
 	@Override
 	public String toString(){
-		return Objects
+		return MoreObjects
 				.toStringHelper(this)
 				.add("type", type)
 				.add("optional", isOptional())

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionSpecBuilder.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/function/FunctionSpecBuilder.java
@@ -40,7 +40,7 @@ import org.xacml4j.v30.pdp.FunctionInvocationException;
 import org.xacml4j.v30.pdp.FunctionParamSpec;
 import org.xacml4j.v30.pdp.FunctionSpec;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 
@@ -541,12 +541,12 @@ public final class FunctionSpecBuilder
 
 		@Override
 		public String toString(){
-			return Objects.toStringHelper(this)
-					.add("functionId", functionId)
-					.add("legacyId", legacyId)
-					.add("evaluateParams", evaluateParameters)
-					.add("params", parameters)
-					.toString();
+			return MoreObjects.toStringHelper(this)
+			                  .add("functionId", functionId)
+			                  .add("legacyId", legacyId)
+			                  .add("evaluateParams", evaluateParameters)
+			                  .add("params", parameters)
+			                  .toString();
 		}
 
 		@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/pip/AttributeSet.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/pip/AttributeSet.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import org.xacml4j.v30.AttributeDesignatorKey;
 import org.xacml4j.v30.BagOfAttributeExp;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Ticker;
@@ -141,11 +142,11 @@ public final class AttributeSet
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("id", d.getId())
-		.add("issuer", d.getIssuer())
-		.add("values", values)
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("id", d.getId())
+		                  .add("issuer", d.getIssuer())
+		                  .add("values", values)
+		                  .toString();
 	}
 
 	@Override

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/pip/Content.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/pip/Content.java
@@ -26,6 +26,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xacml4j.util.DOMUtil;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Ticker;
@@ -61,10 +62,10 @@ public final class Content
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("id", d.getId())
-		.add("content", DOMUtil.toString((Element)content))
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("id", d.getId())
+		                  .add("content", DOMUtil.toString((Element)content))
+		                  .toString();
 	}
 
 	public static class Builder

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/pip/DefaultResolverContext.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/pip/DefaultResolverContext.java
@@ -30,6 +30,7 @@ import org.xacml4j.v30.BagOfAttributeExp;
 import org.xacml4j.v30.EvaluationContext;
 import org.xacml4j.v30.EvaluationException;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Ticker;
@@ -87,11 +88,11 @@ final class DefaultResolverContext implements
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-				.add("context", context)
-				.add("descriptor", descriptor)
-				.add("keys", keys)
-				.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("context", context)
+		                  .add("descriptor", descriptor)
+		                  .add("keys", keys)
+		                  .toString();
 	}
 
 }

--- a/xacml-core/src/main/java/org/xacml4j/v30/spi/pip/ResolverCacheKey.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/spi/pip/ResolverCacheKey.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.xacml4j.v30.BagOfAttributeExp;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -76,10 +77,10 @@ public final class ResolverCacheKey implements Serializable
 
 	@Override
 	public String toString(){
-		return Objects.toStringHelper(this)
-		.add("id", resolverId)
-		.add("keys", keys.toString())
-		.toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("id", resolverId)
+		                  .add("keys", keys.toString())
+		                  .toString();
 	}
 
 	public static class Builder

--- a/xacml-core/src/main/java/org/xacml4j/v30/types/BaseAttributeExp.java
+++ b/xacml-core/src/main/java/org/xacml4j/v30/types/BaseAttributeExp.java
@@ -30,6 +30,7 @@ import org.xacml4j.v30.EvaluationException;
 import org.xacml4j.v30.ExpressionVisitor;
 import org.xacml4j.v30.ValueType;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -74,7 +75,7 @@ public abstract class BaseAttributeExp<T>
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this).
+		return MoreObjects.toStringHelper(this).
 		add("Value", value).
 		add("Type", type).toString();
 	}

--- a/xacml-core/src/test/java/org/xacml4j/v30/pdp/profiles/MultipleResourcesViaXPathExpressionHandlerTest.java
+++ b/xacml-core/src/test/java/org/xacml4j/v30/pdp/profiles/MultipleResourcesViaXPathExpressionHandlerTest.java
@@ -231,14 +231,14 @@ public class MultipleResourcesViaXPathExpressionHandlerTest
 		Attribute selector10 = r1.getOnlyEntity(Categories.RESOURCE).getOnlyAttribute(MultipleResourcesViaXPathExpressionHandler.CONTENT_SELECTOR);
 		Attribute selector11 = r1.getOnlyEntity(Categories.SUBJECT_ACCESS).getOnlyAttribute(MultipleResourcesViaXPathExpressionHandler.CONTENT_SELECTOR);
 
-		assertEquals(XPathExp.of("//md:record/md:patient[1]", Categories.RESOURCE),  Iterables.getOnlyElement(selector10.getValues()));
-		assertEquals(XPathExp.of("//md:record/md:patient[2]/md:patientDoB[1]/@md:attrn1", Categories.SUBJECT_ACCESS),  Iterables.getOnlyElement(selector11.getValues()));
+		assertEquals(XPathExp.of("//md:record/md:patient[2]", Categories.RESOURCE),  Iterables.getOnlyElement(selector10.getValues()));
+		assertEquals(XPathExp.of("//md:record/md:patient[1]/md:patientDoB[1]/@md:attrn1", Categories.SUBJECT_ACCESS),  Iterables.getOnlyElement(selector11.getValues()));
 
 		Attribute selector20 = r2.getOnlyEntity(Categories.RESOURCE).getOnlyAttribute(MultipleResourcesViaXPathExpressionHandler.CONTENT_SELECTOR);
 		Attribute selector21 = r2.getOnlyEntity(Categories.SUBJECT_ACCESS).getOnlyAttribute(MultipleResourcesViaXPathExpressionHandler.CONTENT_SELECTOR);
 
-		assertEquals(XPathExp.of("//md:record/md:patient[2]", Categories.RESOURCE),  Iterables.getOnlyElement(selector20.getValues()));
-		assertEquals(XPathExp.of("//md:record/md:patient[1]/md:patientDoB[1]/@md:attrn1", Categories.SUBJECT_ACCESS),  Iterables.getOnlyElement(selector21.getValues()));
+		assertEquals(XPathExp.of("//md:record/md:patient[1]", Categories.RESOURCE),  Iterables.getOnlyElement(selector20.getValues()));
+		assertEquals(XPathExp.of("//md:record/md:patient[2]/md:patientDoB[1]/@md:attrn1", Categories.SUBJECT_ACCESS),  Iterables.getOnlyElement(selector21.getValues()));
 
 
 		Attribute selector30 = r3.getOnlyEntity(Categories.RESOURCE).getOnlyAttribute(MultipleResourcesViaXPathExpressionHandler.CONTENT_SELECTOR);


### PR DESCRIPTION
Harshilkumar PatelHarshilkumar Patel
Guava dependency version upgrade